### PR TITLE
Require sudo mode to impersonate another user

### DIFF
--- a/app/controllers/impersonation_controller.rb
+++ b/app/controllers/impersonation_controller.rb
@@ -2,6 +2,8 @@ class ImpersonationController < ApplicationController
   before_filter :require_login
   before_filter :require_admin, only: [:create]
 
+  require_sudo_mode :create
+
   def create
     if !session[:true_user_id]
       session[:true_user_id] = User.current.id


### PR DESCRIPTION
Redmine introduced a Sudo Mode with version 3.1 http://www.redmine.org/issues/19851, this should be required (if configured) for the impersonate functionality.

This PR adds the sudo mode requirement to start impersonating another user.