### PR TITLE
Only impersonate active non-anonymous users

### DIFF
--- a/app/controllers/impersonation_controller.rb
+++ b/app/controllers/impersonation_controller.rb
@@ -5,7 +5,7 @@ class ImpersonationController < ApplicationController
   def create
     if !session[:true_user_id]
       session[:true_user_id] = User.current.id
-      impersonated_user = User.find(params[:user_id])
+      impersonated_user = User.active.logged.find(params[:user_id])
       User.current = impersonated_user
       session[:user_id] = impersonated_user.id
 


### PR DESCRIPTION
This makes sure impersonation only works for active users.

This is also consistent with and enforces the UI https://github.com/rgtk/redmine_impersonate/blob/master/lib/redmine_impersonate/hook.rb#L41, as the "impersonate" button will not be shown on pages for inactive users.