### PR TITLE
Fix undefined method before_filter (> Rails 5.1)

### DIFF
--- a/app/controllers/impersonation_controller.rb
+++ b/app/controllers/impersonation_controller.rb
@@ -1,6 +1,6 @@
 class ImpersonationController < ApplicationController
-  before_filter :require_login
-  before_filter :require_admin, only: [:create]
+  before_action :require_login
+  before_action :require_admin, only: [:create]
 
   require_sudo_mode :create if Redmine::VERSION::STRING >= '3.1'
 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,0 +1,3 @@
+fr:
+  notice_impersonating_user: Connecté en tant que %{user}
+  button_impersonate: Imiter


### PR DESCRIPTION
Hi again !
Fix compatibility on Redmine 4.0.
`before_filter` has been deprecated in Rails 5.0, removed in 5.1 and replaced by `before_action` method.
I took the opportunity to add the French translation too :wink: 