### PR TITLE
fix incorrect hash key

### DIFF
--- a/app/controllers/impersonation_controller.rb
+++ b/app/controllers/impersonation_controller.rb
@@ -32,7 +32,7 @@ class ImpersonationController < ApplicationController
 
     if true_user && true_user.active?
       self.logged_user = true_user
-      session.delete(:real_user_id)
+      session.delete(:true_user_id)
     end
 
     redirect_to :back


### PR DESCRIPTION
I digged into codebase and found the code [here](https://github.com/rgtk/redmine_impersonate/blob/78c925d1a455de2e626caa4548b7de0ca0a25845/lib/redmine_impersonate/hook.rb#L23) need `true_user_id` to be deleted when canceled impersonation.

```ruby
        if session[:true_user_id]
          true_user = User.find(session[:true_user_id])
          impersonated_user = User.current
          style = 'margin: 0; padding: 10px; border-width: 0 0 2px; background-image: none'

          content_tag :div, id: 'impersonation-bar', class: 'flash error', style: style do
            concat link_to l(:button_cancel), { controller: 'impersonation', action: 'destroy' },
                           method: :delete, style: 'float: right'
            concat l(:notice_impersonating_user, user: impersonated_user.name)
          end
        end
      end
```

So I simply fixed #16 .

