### PR TITLE
Patch: fix impersonation issue with 2FA

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,12 @@ in mind to keep it functional across many version of software it uses.
   * Redmine (`>= 4.0`)
   * Redmine (`>= 3.0`, use [redmine-3.x branch](https://github.com/rgtk/redmine_impersonate/tree/redmine-3.x))
   * Redmine (`2.0+`, use [redmine-2.x branch](https://github.com/rgtk/redmine_impersonate/tree/redmine-2.x))
+
+Testing
+-------
+
+Run the plugin's test suite from a Redmine root directory:
+
+```
+RAILS_ENV=test bundle exec rake redmine:plugins:test NAME=redmine_impersonate
+```

--- a/app/controllers/impersonation_controller.rb
+++ b/app/controllers/impersonation_controller.rb
@@ -21,6 +21,8 @@ class ImpersonationController < ApplicationController
 
       # Don't require password change of target user
       session.delete(:pwd)
+      # Skip two-factor authentication activation for impersonated user
+      session.delete(:must_activate_twofa)
     end
 
     # Redirect to the home with the new impersonated user
@@ -35,6 +37,6 @@ class ImpersonationController < ApplicationController
       session.delete(:true_user_id)
     end
 
-    redirect_to :back
+    redirect_back fallback_location: home_url
   end
 end

--- a/test/integration/impersonation_test.rb
+++ b/test/integration/impersonation_test.rb
@@ -59,6 +59,19 @@ class ImpersonationTest < ActionDispatch::IntegrationTest
     assert_select '#impersonation-bar'
   end
 
+  test "impersonating user requiring twofa works" do
+    log_user('admin', 'admin')
+
+    user = User.find_by_login('jsmith')
+
+    with_settings twofa: '2' do
+      post '/admin/impersonation', params: {user_id: user.id}
+      follow_redirect!
+      assert_equal user, User.find(session[:user_id])
+      assert_nil session[:must_activate_twofa]
+    end
+  end
+
   test "impersonating user as user" do
     log_user('jsmith', 'jsmith')
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,2 +1,23 @@
+# Suppress noisy deprecation warnings emitted by Redmine and dependencies
+module Warning
+  class << self
+    alias_method :original_warn, :warn
+
+    def warn(message, *args)
+      return if message.to_s.include?("PG::Coder.new(hash) is deprecated")
+      original_warn(message, *args)
+    end
+  end
+end
+
 # Load the Redmine helper
 require File.expand_path(File.dirname(__FILE__) + '/../../../test/test_helper')
+
+# Required for certain Redmine helpers in Ruby 3
+require 'ostruct'
+
+# Avoid deprecation noise during test runs
+ActiveSupport::Deprecation.behavior = :silence
+
+# Required for certain Redmine helpers in Ruby 3
+require 'ostruct'


### PR DESCRIPTION
-     Skip mandatory two-factor activation during impersonation, letting admins switch to users who haven’t set up 2FA
-     Add a regression test confirming impersonation works even when 2FA is enforced
-     Document how to run the plugin’s test suite and clean up legacy Rails deprecation usage
